### PR TITLE
Remove CUDA install commands for upcoming CryoSPARC release

### DIFF
--- a/install-cryosparc_v1.sh
+++ b/install-cryosparc_v1.sh
@@ -3,28 +3,9 @@
 . "/etc/parallelcluster/cfnconfig"
 
 if [ "${cfn_node_type}" == "MasterServer" ]; then
-   CUDA_INSTALL_PATH=/shared/cuda
    CRYOSPARC_INSTALL_PATH=/shared/cryosparc
    LICENSE_ID=$2
-   CUDA_VERSION=11.8.0
-   CUDA_INSTALLER_FILENAME=cuda_11.8.0_520.61.05_linux.run
-   CUDA_DOWNLOAD_PATH=https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run
-   CUDA_TOOLKIT_PATH=${CUDA_INSTALL_PATH}/cuda-${CUDA_VERSION}
    yum -y update
-
-   # Install CUDA Toolkit
-   mkdir -p ${CUDA_INSTALL_PATH}
-   cd ${CUDA_INSTALL_PATH}
-   wget ${CUDA_DOWNLOAD_PATH}
-   sh ${CUDA_INSTALLER_FILENAME} --defaultroot=/shared/cuda --toolkit --toolkitpath=${CUDA_TOOLKIT_PATH} --samples --silent
-   rm ${CUDA_INSTALLER_FILENAME}
-
-   # Add CUDA to the path
-   cat > /etc/profile.d/cuda.sh << 'EOF'
-PATH=$PATH:@CUDA_TOOLKIT_PATH@/bin
-EOF
-   sed -i "s|@CUDA_TOOLKIT_PATH@|${CUDA_TOOLKIT_PATH}|g" /etc/profile.d/cuda.sh
-   . /etc/profile.d/cuda.sh
 
    # Download cryoSPARC
    mkdir -p ${CRYOSPARC_INSTALL_PATH}
@@ -60,9 +41,7 @@ EOF
    cd ${CRYOSPARC_INSTALL_PATH}
    tar -xf cryosparc_worker.tar.gz
    cd cryosparc_worker
-   ./install.sh --license ${LICENSE_ID} \
-      --cudapath ${CUDA_TOOLKIT_PATH} \
-      --yes
+   ./install.sh --license ${LICENSE_ID} --yes
 
    rm ${CRYOSPARC_INSTALL_PATH}/*.tar.gz
    chown -R ec2-user: /shared/cryosparc
@@ -71,7 +50,7 @@ EOF
    /bin/su -c "${CRYOSPARC_INSTALL_PATH}/cryosparc_master/bin/cryosparcm start" - ec2-user
 
       # Create cluster config files for each GPU partition in SLURM
-   for PARTITION in gpu-large gpu-med gpu-small 
+   for PARTITION in gpu-large gpu-med gpu-small
    do
 
    cat > ${CRYOSPARC_INSTALL_PATH}/cluster_info.json <<EOF


### PR DESCRIPTION
Future CryoSPARC releases will not require a dedicated CUDA Toolkit installation. Merge pending new CryoSPARC release.